### PR TITLE
Add support to 'Context' as an optional feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ Present:
     - Also produces summary report and statistics when given a stream
   - execute your lambda function under a user-supplied IAM Role (Lambda Execution Role)
   - picks up any library present in ``./lib`` directory
+  - Take context from file
 
 
 Planned:
   - SQS support (though for now, you can easily pipe AWS CLI output to Emulambda stdin)
   - Kinesis support / emulation
   - An AWS event library, for common integrations with other services
-  - Context support (probably an optional argument to provide context objects in the same way as event objects)
 
 ## Installation
 1. `git clone` [the Emulambda repo](https://github.com/fugue/emulambda/)
@@ -43,7 +43,7 @@ Planned:
 ## Usage
 
 ```
-usage: emulambda [-h] [-s] [-t TIMEOUT] [-v] lambdapath eventfile
+usage: emulambda [-h] [-s] [-t TIMEOUT] [-v] lambdapath eventfile contextfile
 
 Python AWS Lambda Emulator. At present, AWS Lambda supports Python 2.7 only.
 
@@ -64,6 +64,7 @@ optional arguments:
                         maximum.
   -v, --verbose         Verbose mode. Provides exact function run, timing,
                         etc.
+  contextfile           A JSON file to give as the `context` argument to the function
 ```
 
 ## Quick Start
@@ -98,6 +99,42 @@ In this example, `emulambda` is:
   1. Invoking the function, and measuring elapsed time and memory consumption.
   1. Reporting on resource usage.
   1. Printing the function result.
+
+### Single-Event Mode with Context
+
+From the repository root, run:
+`emulambda example.example_handler example/example.json example/context.json -v `
+
+You should see output similar to the following:
+```
+Function name is:  example
+Executed example.example_handler
+Estimated...
+...execution clock time:     212ms (300ms billing bucket)
+...execution peak RSS memory:    368M (385900544 bytes)
+----------------------RESULT----------------------
+value1
+```
+
+Note that without the `-v` switch, the function return is printed to `stdout` with no modification or other information.
+
+```
+$ emulambda example.example_handler example/example.json example/context.json
+Function name is:  example
+value1
+```
+
+#### What's happening?
+
+In this example, `emulambda` is:
+  1. Loading the `example_handler` function from the `example` module.
+  1. Deserializing `stdin` (which is the contents of `example/example.json`) as the `event` argument for the function.
+  1. Deserializing `stdin` (which is the contents of `example/context.json`) as the `context` argument for the function.
+  1. Invoking the function, and measuring elapsed time and memory consumption.
+  1. Reporting on resource usage.
+  1. Printing the function result.
+
+====
 
 ### Event Stream Mode
 

--- a/example/__init__.py
+++ b/example/__init__.py
@@ -11,4 +11,6 @@ def very_inefficient(recursion, accumulator):
 
 def example_handler(event, context):
     result = very_inefficient(512, '')
+    if hasattr(context, 'function_name'):
+	print("Function name is: ", context.function_name)
     return event['key1']  # echo first key value

--- a/example/context.json
+++ b/example/context.json
@@ -1,0 +1,3 @@
+{
+	"function_name": "example"
+}


### PR DESCRIPTION
Hi,

 First, thanks a lot for spending time on building Emulambda - That was very straightforward and simple to use compared to others!

 During development in one of my functions I noticed that the 'context' object was None and I couldn't fake it as I do with 'event' currently, so I thought I would try to understand the code and create this PR.

 This PR has:

* Updates Example folder with both `context.json` and modified version of `__init__.py` to print `context.function_name` if it exists
* Add `contextfile` optional argument to ensure it doesn't break compatibility for those already using emulambda
* Updates documentation to reflect examples on using it + remove 'Context' from **Planned* section

Let me know what you think.

Tks!