### PR TITLE
allow handler form of 'file-name.function-name'

### DIFF
--- a/test.py
+++ b/test.py
@@ -51,6 +51,20 @@ class EmulambdaImportLambdaTest(unittest.TestCase):
         except:
             assert True
 
+    def test_import_lambda_correct_file(self):
+        try:
+            func = emulambda.import_lambda('testmodule/foo.bar')
+            assert func
+        except BaseException as e:
+            self.fail("Unable to import module and find function.\n%s" % e.message)
+
+    def test_import_lambda_wrong_file(self):
+        try:
+            emulambda.import_lambda('testmodule/foo.bar.biz')
+            self.fail("Somehow, we imported a file.")
+        except:
+            assert True
+
     def test_import_lambda_missing(self):
         try:
             emulambda.import_lambda('testmodule.bar')

--- a/testmodule/foo.py
+++ b/testmodule/foo.py
@@ -1,0 +1,4 @@
+__author__ = 'dominiczippilli'
+
+def bar():
+    pass


### PR DESCRIPTION
When I use 'emulambda' in handler form of 'file-name.function-name', the script failes.
https://docs.aws.amazon.com/lambda/latest/dg/python-programming-model-handler-types.html
```
$ emulambda functions/autoscale/handler.autoscale functions/autoscale/test_event.json 
It looks like you've given a Python *file* path as the lambdapath argument. This must be an *import* path, following the form of [module 1].[module 2...n].[function]
Perhaps it is something like `handler.autoscale`?
```
I fix it and could you merge this change?