### PR TITLE
Python3 compat

### DIFF
--- a/example/__init__.py
+++ b/example/__init__.py
@@ -5,12 +5,12 @@ def very_inefficient(recursion, accumulator):
         accumulator = accumulator + ('f' * 1024 + '\n')
         very_inefficient(recursion - 1, accumulator)
     else:
-        some_str = ' ' * (10 ** 9 / 4)
+        some_str = ' ' * int(10 ** 9 / 4)
         return accumulator
 
 
 def example_handler(event, context):
     result = very_inefficient(512, '')
     if hasattr(context, 'function_name'):
-	print("Function name is: ", context.function_name)
+       print("Function name is: ", context.function_name)
     return event['key1']  # echo first key value

--- a/test.py
+++ b/test.py
@@ -51,6 +51,20 @@ class EmulambdaImportLambdaTest(unittest.TestCase):
         except:
             assert True
 
+    def test_import_lambda_correct_file(self):
+        try:
+            func = emulambda.import_lambda('testmodule/foo.bar')
+            assert func
+        except BaseException as e:
+            self.fail("Unable to import module and find function.\n%s" % e.message)
+
+    def test_import_lambda_wrong_file(self):
+        try:
+            emulambda.import_lambda('testmodule/foo.bar.biz')
+            self.fail("Somehow, we imported a file.")
+        except:
+            assert True
+
     def test_import_lambda_missing(self):
         try:
             emulambda.import_lambda('testmodule.bar')

--- a/testmodule/foo.py
+++ b/testmodule/foo.py
@@ -1,0 +1,4 @@
+__author__ = 'dominiczippilli'
+
+def bar():
+    pass


### PR DESCRIPTION
Compatible change to allow install of emulambda and example to run with python3.

* fixed tab, converted to spaces
* explicit int() cast for   ' ' * float

Install with

`pip3 install emulambda`

Test example now runs.

Prior error:
```

  File "/home/dlee/git.repo/emulambda/example/__init__.py", line 8, in very_inefficient
    some_str = ' ' * (10 * 9 / 4)
TypeError: can't multiply sequence by non-int of type 'float'
EMULAMBDA: LAMBDA ERROR

```